### PR TITLE
Composer Override

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -28,7 +28,7 @@ echo "Using build directory ${BUILDENV}"
  
 git clone https://github.com/AOEpeople/MageTestStand.git "${BUILDENV}"
 cp -rf "${WORKSPACE}" "${BUILDENV}/.modman/"
-if [ -d "${WORKSPACE}/vendor/*" ] ; then
+if [ -d "${WORKSPACE}/vendor" ] ; then
   cp -rf "${WORKSPACE}/vendor/*" "${BUILDENV}/vendor/"
 fi
 ${BUILDENV}/install.sh

--- a/setup.sh
+++ b/setup.sh
@@ -28,10 +28,10 @@ echo "Using build directory ${BUILDENV}"
  
 git clone https://github.com/AOEpeople/MageTestStand.git "${BUILDENV}"
 cp -rf "${WORKSPACE}" "${BUILDENV}/.modman/"
-if [ -d "${WORKSPACE}/vendor" ] ; then
-  cp -rf "${WORKSPACE}/vendor/*" "${BUILDENV}/vendor/"
-fi
 ${BUILDENV}/install.sh
+if [ -d "${WORKSPACE}/vendor" ] ; then
+  cp -rf ${WORKSPACE}/vendor/* "${BUILDENV}/vendor/"
+fi
  
 cd ${BUILDENV}/htdocs
 ${BUILDENV}/bin/phpunit --colors -d display_errors=1

--- a/setup.sh
+++ b/setup.sh
@@ -28,6 +28,9 @@ echo "Using build directory ${BUILDENV}"
  
 git clone https://github.com/AOEpeople/MageTestStand.git "${BUILDENV}"
 cp -rf "${WORKSPACE}" "${BUILDENV}/.modman/"
+if [ -d "${WORKSPACE}/vendor/*" ] ; then
+  cp -rf "${WORKSPACE}/vendor/*" "${BUILDENV}/vendor/"
+fi
 ${BUILDENV}/install.sh
  
 cd ${BUILDENV}/htdocs


### PR DESCRIPTION
Sometimes a module has its own dependencies and you want to do a "composer install" before running the MageTestStand setup.

I changed the setup so that it copies the vendor directory from the working directory if it exists, overwriting the dependencies installed by MageTestStand
