### PR TITLE
updated composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "minimum-stability": "dev",
     "require": {
         "aoepeople/composer-installers": "*",
-        "ivanchepurnyi/ecomdev_phpunit": "dev-dev"
+        "ecomdev/ecomdev_phpunit": "dev-dev"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
Since the `composer.json` in the development branch refers to `ecomdev/ecomdev_phpunit` (see https://github.com/AOEpeople/EcomDev_PHPUnit/blob/dev/composer.json), we should refer to `ecomdev` here as well.