### PR TITLE
Define  to use a customized MageTestStand repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It uses following tools:
 - In case you want to allow EcomDev_PHPUnit to use the main database instead of the test database you can set following environment variable to 1. This might be required if you're planning on writing integration tests.
   - `MAGENTO_DB_ALLOWSAME`
 - Environment variable `MAGENTO_VERSION` with valid Magento version for n98-magerun's install command
+- Define `MAGETESTSTAND_URL` to use a customized MageTestStand repository.
 
 ## General usage
 
@@ -52,6 +53,7 @@ env:
 #  global:
 #    - MAGENTO_DB_ALLOWSAME=1
 #    - SKIP_CLEANUP=1
+#    - MAGETESTSTAND_URL=https://github.com/xxxx/MageTestStand.git
   - MAGENTO_VERSION=magento-ce-1.9.0.1
   - MAGENTO_VERSION=magento-ce-1.8.1.0
   - MAGENTO_VERSION=magento-ce-1.8.0.0

--- a/setup.sh
+++ b/setup.sh
@@ -19,14 +19,17 @@ fi
 
 if [ -z $WORKSPACE ] ; then
   echo "No workspace configured, please set your WORKSPACE environment"
-  exit
+  exit 1
 fi
- 
+
+if [ -z $MAGETESTSTAND_URL ] ; then
+    MAGETESTSTAND_URL="https://github.com/AOEpeople/MageTestStand.git"
+fi
+
 BUILDENV=`mktemp -d /tmp/mageteststand.XXXXXXXX`
- 
-echo "Using build directory ${BUILDENV}"
- 
-git clone https://github.com/AOEpeople/MageTestStand.git "${BUILDENV}"
+
+echo "Cloning ${MAGETESTSTAND_URL} to ${BUILDENV}"
+git clone "${MAGETESTSTAND_URL}" "${BUILDENV}"
 cp -rf "${WORKSPACE}" "${BUILDENV}/.modman/"
 ${BUILDENV}/install.sh
 if [ -d "${WORKSPACE}/vendor" ] ; then


### PR DESCRIPTION
This eases the testing (you don't have to modify setup.sh when you want to test mageteststand from different repo).

see https://github.com/ambimax/MageTestStand/commit/3f024dc280c8d56243e4af87c1b8b8c1ff3c5d6c